### PR TITLE
Remove push trigger for master branch

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,8 +1,6 @@
 name: zThread Continuous Performance Benchmark Suite
 
 on:
-  push:
-    branches: [ master ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This pull request makes a small change to the GitHub Actions workflow configuration by removing the automatic trigger for the benchmark workflow on pushes to the `master` branch. The workflow can now only be triggered manually.Removed push trigger for master branch from workflow.

## Description

Brief description of the changes.

## Motivation

Why is this change needed?

## Changes

- [ ] Change 1
- [ ] Change 2

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] All tests pass (`./mvnw clean verify`)
- [ ] Quality checks pass (`./mvnw verify -Pquality`)

## Checklist

- [ ] Code follows Google Java Style (run `./mvnw spotless:apply`)
- [ ] Javadoc added for public APIs
- [ ] No breaking changes (or documented in description)
- [ ] CHANGELOG.md updated
